### PR TITLE
Made changes so their is a rule that checks to see if the activity name ...

### DIFF
--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic.Tests.Integration/ActivityTests.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic.Tests.Integration/ActivityTests.cs
@@ -84,7 +84,37 @@ namespace Magenic.BadgeApplication.BusinessLogic.Tests.Integration
             activityEdit = ((IActivityEdit) await ActivityEdit.GetActivityEditByIdAsync(id));
 
             Assert.Fail("Activity Edit Fail should not return.");
-
         }
+
+        [TestMethod]
+        public async Task ActivityNameSameAsExisting()
+        {
+            var activityEdit = await ActivityEdit.GetActivityEditByIdAsync(1);
+            var secondActivity = await ActivityEdit.GetActivityEditByIdAsync(2);
+            activityEdit.Name = secondActivity.Name;
+
+            Assert.IsFalse(activityEdit.IsValid);
+        }
+
+        [TestMethod]
+        public async Task ActivityNameNotSameAsExisting()
+        {
+            var activityEdit = await ActivityEdit.GetActivityEditByIdAsync(1);
+            activityEdit.Name = Guid.NewGuid().ToString();
+
+            Assert.IsTrue(activityEdit.IsValid);
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", MessageId = "NameAble"), TestMethod]
+        public async Task ActivityNameAbleToBeSetToDbValue()
+        {
+            var activityEdit = await ActivityEdit.GetActivityEditByIdAsync(1);
+            var oldName = activityEdit.Name;
+            activityEdit.Name = Guid.NewGuid().ToString();
+            activityEdit.Name = oldName;
+
+            Assert.IsTrue(activityEdit.IsValid);
+        }
+
     }
 }

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic.Tests/DefaultActivityStatusTests.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic.Tests/DefaultActivityStatusTests.cs
@@ -11,7 +11,6 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Magenic.BadgeApplication.BusinessLogic.Tests
@@ -122,11 +121,6 @@ namespace Magenic.BadgeApplication.BusinessLogic.Tests
 
             ruleRunner.Execute(ruleContext);
 
-            while (ruleContext.Results.Count == 0)
-            {
-                Thread.Sleep(50);
-            }
-
             Assert.IsNotNull(newRule);
         }
 
@@ -153,11 +147,6 @@ namespace Magenic.BadgeApplication.BusinessLogic.Tests
             var ruleRunner = (IBusinessRule)newRule;
 
             ruleRunner.Execute(ruleContext);
-
-            while (ruleContext.Results.Count == 0)
-            {
-                Thread.Sleep(50);
-            }
 
             Assert.IsNotNull(newRule);
             Assert.IsTrue(ruleContext.OutputPropertyValues.Count == 1);
@@ -187,11 +176,6 @@ namespace Magenic.BadgeApplication.BusinessLogic.Tests
             var ruleRunner = (IBusinessRule)newRule;
 
             ruleRunner.Execute(ruleContext);
-
-            while (ruleContext.Results.Count == 0)
-            {
-                Thread.Sleep(50);
-            }
 
             Assert.IsNotNull(newRule);
             Assert.IsTrue(ruleContext.OutputPropertyValues.Count == 1);
@@ -227,6 +211,11 @@ namespace Magenic.BadgeApplication.BusinessLogic.Tests
             }
 
             public void Delete(int activityId)
+            {
+                throw new NotImplementedException();
+            }
+
+            public bool ActivityNameExists(int id, string name)
             {
                 throw new NotImplementedException();
             }

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/ActivityEdit.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/ActivityEdit.cs
@@ -3,11 +3,13 @@ using Csla;
 using Csla.Rules;
 using Csla.Rules.CommonRules;
 using Magenic.BadgeApplication.BusinessLogic.Framework;
+using Magenic.BadgeApplication.BusinessLogic.Rules;
 using Magenic.BadgeApplication.Common.DTO;
 using Magenic.BadgeApplication.Common.Enums;
 using Magenic.BadgeApplication.Common.Interfaces;
 using System;
 using System.Threading.Tasks;
+using NuGet;
 
 namespace Magenic.BadgeApplication.BusinessLogic.Activity
 {
@@ -69,12 +71,20 @@ namespace Magenic.BadgeApplication.BusinessLogic.Activity
             this.BusinessRules.AddRule(new MaxLength(NameProperty, 100));
             this.BusinessRules.AddRule(new Required(NameProperty));
             this.BusinessRules.AddRule(new IsInRole(AuthorizationActions.WriteProperty, RequiresApprovalProperty, PermissionType.Administrator.ToString()));
+            
+            // Only run this rule if the associated properties are otherwise valid.
+            this.BusinessRules.AddRule(new NoDuplicates(NameProperty, IdProperty, NameExists) { Priority = 1 });
         }
 
         #endregion Rules
 
         #region Data Access
 
+        internal bool NameExists(int id, string name)
+        {
+            return ActivityNameExists.NameAlreadyExists(id, name);
+        }
+        
         [RunLocal]
         protected override void DataPortal_Create()
         {

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/ActivityNameExists.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/ActivityNameExists.cs
@@ -1,6 +1,7 @@
 ﻿using Autofac;
 using Csla;
 using Magenic.BadgeApplication.BusinessLogic.Framework;
+using Magenic.BadgeApplication.Common.Interfaces;
 using System;
 using System.Threading.Tasks;
 
@@ -11,13 +12,14 @@ namespace Magenic.BadgeApplication.BusinessLogic.Activity
     {
         private bool NameExists { get; set; }
         private string Name { get; set; }
-        
+        private int Id { get; set; }
+
         #region Factory Methods
 
-        public async static Task<bool> NameAlreadyExistsAsync(string name)
+        public static bool NameAlreadyExists(int id, string name)
         {
-            var nameExistsCommand = new ActivityNameExists {Name = name};
-            nameExistsCommand = await IoC.Container.Resolve<IDataPortal<ActivityNameExists>>().ExecuteAsync(nameExistsCommand);
+            var nameExistsCommand = new ActivityNameExists {Name = name, Id = id};
+            nameExistsCommand = IoC.Container.Resolve<IObjectFactory<ActivityNameExists>>().Execute(nameExistsCommand);
             return nameExistsCommand.NameExists;
         }
 
@@ -27,7 +29,8 @@ namespace Magenic.BadgeApplication.BusinessLogic.Activity
 
         protected override void DataPortal_Execute()
         {
-            this.NameExists = this.Name == "Foo";
+            var dal = IoC.Container.Resolve<IActivityEditDAL>();
+            this.NameExists = dal.ActivityNameExists(this.Id, this.Name);
         }
 
         #endregion Data Access

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/SubmitActivity.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Activity/SubmitActivity.cs
@@ -119,7 +119,9 @@ namespace Magenic.BadgeApplication.BusinessLogic.Activity
 
             this.BusinessRules.AddRule(new MinValue<int>(EmployeeIdProperty, 1));
             this.BusinessRules.AddRule(new MinValue<int>(ActivityIdProperty, 1));
-            this.BusinessRules.AddRule(new Rules.DefaultActivityStatus(ActivityIdProperty, StatusProperty, ApprovedByIdProperty));
+
+            // Only run this rule if the associated properties are otherwise valid.
+            this.BusinessRules.AddRule(new Rules.DefaultActivityStatus(ActivityIdProperty, StatusProperty, ApprovedByIdProperty) { Priority = 1 });
         }
 
         #endregion Rules

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Rules/DefaultActivityStatus.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Rules/DefaultActivityStatus.cs
@@ -1,4 +1,5 @@
-﻿using Autofac;
+﻿using System.Globalization;
+using Autofac;
 using Csla.Core;
 using Csla.Rules;
 using Magenic.BadgeApplication.BusinessLogic.Framework;
@@ -10,8 +11,11 @@ using System.Linq;
 
 namespace Magenic.BadgeApplication.BusinessLogic.Rules
 {
-    public class DefaultActivityStatus : BusinessRule 
+    public class DefaultActivityStatus : BusinessRule
     {
+        private string StatusName;
+        private string ApprovedByIdName;
+
         public DefaultActivityStatus(IPropertyInfo activityIdProperty, IPropertyInfo activityStatusProperty, IPropertyInfo approvedByIdProperty)
             : base(activityIdProperty)
         {
@@ -40,45 +44,40 @@ namespace Magenic.BadgeApplication.BusinessLogic.Rules
                 throw new ArgumentException("approvedByIdProperty must be a Common.Enums.ActivitySubmissionStatus.");
             }
 
+            this.StatusName = activityStatusProperty.Name;
+            this.ApprovedByIdName = approvedByIdProperty.Name;
             this.InputProperties = new List<IPropertyInfo> { activityIdProperty, activityStatusProperty, approvedByIdProperty };
             this.AffectedProperties.Add(activityStatusProperty);
-            this.IsAsync = true;
         }
 
-        protected async override void Execute(RuleContext context)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
+        protected override void Execute(RuleContext context)
         {
-            try
-            {
-                var activityIdValue = (int)context.InputPropertyValues[PrimaryProperty];
-                var activityStatusProperty = this.InputProperties.Single(p => p.Name == "Status");
-                var activtyStatusValue = (ActivitySubmissionStatus)context.InputPropertyValues[activityStatusProperty];
-                var approvedByIdProperty = this.InputProperties.Single(p => p.Name == "ApprovedById");
-                var approvedByIdValue = (ActivitySubmissionStatus)context.InputPropertyValues[approvedByIdProperty];
+            var activityIdValue = (int)context.InputPropertyValues[PrimaryProperty];
+            var activityStatusProperty = this.InputProperties.Single(p => p.Name == this.StatusName);
+            var activtyStatusValue = (ActivitySubmissionStatus)context.InputPropertyValues[activityStatusProperty];
+            var approvedByIdProperty = this.InputProperties.Single(p => p.Name == this.ApprovedByIdName);
+            var approvedByIdValue = (ActivitySubmissionStatus)context.InputPropertyValues[approvedByIdProperty];
 
-                if (approvedByIdValue == 0
-                    && (activtyStatusValue == ActivitySubmissionStatus.Unset
-                    || activtyStatusValue == ActivitySubmissionStatus.AwaitingApproval
-                    || activtyStatusValue == ActivitySubmissionStatus.Approved))
+            if (approvedByIdValue == 0
+                && (activtyStatusValue == ActivitySubmissionStatus.Unset
+                || activtyStatusValue == ActivitySubmissionStatus.AwaitingApproval
+                || activtyStatusValue == ActivitySubmissionStatus.Approved))
+            {
+                try
                 {
-                    try
-                    {
-                        var activity = await IoC.Container.Resolve<IObjectFactory<IActivityEdit>>().FetchAsync(activityIdValue);
-                        context.AddOutValue(activityStatusProperty,
-                            activity.RequiresApproval
-                                ? ActivitySubmissionStatus.AwaitingApproval
-                                : ActivitySubmissionStatus.Approved);
-                    }
-                    catch (Exception)
-                    {
-                        context.AddErrorResult(PrimaryProperty,
-                            string.Format("Activity id {0} was not able to be retrieved.", activityIdValue));
-                    }
+                    var activityTask = IoC.Container.Resolve<IObjectFactory<IActivityEdit>>().FetchAsync(activityIdValue);
+                    var activity = activityTask.Result;
+                    context.AddOutValue(activityStatusProperty,
+                        activity.RequiresApproval
+                            ? ActivitySubmissionStatus.AwaitingApproval
+                            : ActivitySubmissionStatus.Approved);
                 }
-
-            }
-            finally
-            {
-                context.Complete();
+                catch (Exception)
+                {
+                    context.AddErrorResult(PrimaryProperty,
+                        string.Format(CultureInfo.CurrentCulture, "Activity id {0} was not able to be retrieved.", activityIdValue));
+                }
             }
         }
     }

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Rules/NoDuplicates.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.BusinessLogic/Rules/NoDuplicates.cs
@@ -1,27 +1,31 @@
-﻿using Csla;
+﻿using System.Globalization;
 using Csla.Core;
 using Csla.Rules;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using Magenic.BadgeApplication.BusinessLogic.Activity;
+using System.Linq;
 
 namespace Magenic.BadgeApplication.BusinessLogic.Rules
 {
     public class NoDuplicates : BusinessRule
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]
-        public delegate bool CheckForDuplicates(string value);
+        public delegate bool CheckForDuplicates(int currentId, string value);
 
         private CheckForDuplicates DuplicateCommand;
+        private string IdPropertyName;
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
-        public NoDuplicates(IPropertyInfo primaryProperty, CheckForDuplicates duplicateCommand)
+        public NoDuplicates(IPropertyInfo primaryProperty, IPropertyInfo idProperty, CheckForDuplicates duplicateCommand)
             : base(primaryProperty)
         {
             if (primaryProperty == null)
             {
                 throw new ArgumentException("primaryProperty cannot be null.");
+            }
+            if (idProperty == null)
+            {
+                throw new ArgumentException("idProperty cannot be null.");
             }
             if (duplicateCommand == null)
             {
@@ -31,31 +35,26 @@ namespace Magenic.BadgeApplication.BusinessLogic.Rules
             {
                 throw new ArgumentException("primaryProperty must be a string.");
             }
+            if (idProperty.Type != typeof(int))
+            {
+                throw new ArgumentException("idProperty must be an int.");
+            }
 
-            this.InputProperties = new List<IPropertyInfo> { PrimaryProperty };
+            this.IdPropertyName = idProperty.Name;
+            this.InputProperties = new List<IPropertyInfo> { primaryProperty, idProperty };
             this.DuplicateCommand = duplicateCommand;
-            this.IsAsync = true;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
-        protected async override void Execute(RuleContext context)
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes"), System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "0")]
+        protected override void Execute(RuleContext context)
         {
             var primaryPropertyValue = (string)context.InputPropertyValues[PrimaryProperty];
-            var isNew = ((IBusinessBase)context.Target).IsNew;
+            var idProperty = this.InputProperties.Single(p => p.Name == this.IdPropertyName);
+            var idValue = (int)context.InputPropertyValues[idProperty];
 
-            try
+            if (DuplicateCommand(idValue, primaryPropertyValue))
             {
-                if (isNew)
-                {
-                    if (await ActivityNameExists.NameAlreadyExistsAsync(primaryPropertyValue))
-                    {
-                        context.AddErrorResult(string.Format("The Name {0} already exists.", primaryPropertyValue));
-                    }
-                }
-            }
-            finally
-            {
-                context.Complete();
+                context.AddErrorResult(string.Format(CultureInfo.CurrentCulture, "The value {0} already exists.", primaryPropertyValue));
             }
         }
     }

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Common/Interfaces/IActivityEditDAL.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Common/Interfaces/IActivityEditDAL.cs
@@ -31,5 +31,14 @@ namespace Magenic.BadgeApplication.Common.Interfaces
         /// </summary>
         /// <param name="activityId">The id of the activity to remove.</param>
         void Delete(int activityId);
+        /// <summary>
+        /// Checks to see if a given name already exists in the database for an activity. 
+        /// This method is case insensitive.  It will return not found if a matching name is
+        /// found with the same id.
+        /// </summary>
+        /// <param name="id">The activity id.</param>
+        /// <param name="name">The name to look for.</param>
+        /// <returns>A <see cref="bool"/> indicating if the supplied name was found in the database.</returns>
+        bool ActivityNameExists(int id, string name);
     }
 }

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.DataAccess.EF/ActivityEditDAL.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.DataAccess.EF/ActivityEditDAL.cs
@@ -90,5 +90,15 @@ namespace Magenic.BadgeApplication.DataAccess.EF
                 ctx.SaveChanges();
             }
         }
+
+        public bool ActivityNameExists(int id, string name)
+        {
+            using (var ctx = new Entities())
+            {
+                ctx.Database.Connection.Open();
+                return ctx.Activities.Any(a => a.ActivityName.ToUpper() == name.ToUpper()
+                    && a.ActivityId != id);
+            }
+        }
     }
 }


### PR DESCRIPTION
...already exists.

Also changed the defaulting of the activity submission status based on if the activity is requried to be a synchronous rule instead of asynchronous.
