### PR TITLE
Badge-application #251 - fix for yammer posting url

### DIFF
--- a/Magenic.BadgeApplication/.nuget/NuGet.Config
+++ b/Magenic.BadgeApplication/.nuget/NuGet.Config
@@ -3,4 +3,8 @@
   <solution>
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
+  <packageSources>
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="aspnetwebstacknightlyrelease" value="https://www.myget.org/f/aspnetwebstacknightlyrelease/" />
+  </packageSources>  
 </configuration>

--- a/Magenic.BadgeApplication/.nuget/NuGet.Config
+++ b/Magenic.BadgeApplication/.nuget/NuGet.Config
@@ -4,7 +4,6 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="aspnetwebstacknightlyrelease" value="https://www.myget.org/f/aspnetwebstacknightlyrelease/" />
+    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />   
   </packageSources>  
 </configuration>

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Console/App.config
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Console/App.config
@@ -18,7 +18,7 @@
     <add key="NotificationDay" value="Monday"/>
     <add key="NotificationHourOfDay" value="12"/>
     <add key="YammerMessage" value="body=Attention Magenincons [[user:{0}]] has earned the {1} badge!&amp;broadcast={2}&amp;og_url={3}&amp;og_image={4}&amp;og_title={5}&amp;og_description={6}"/>
-    <add key="YammerToken" value="Y3SGAUBvgDRVQWeTNfBA" />
+    <add key="YammerToken" value="" />
     <add key="YammerCurrentUserURL" value="https://www.yammer.com/api/v1/users/current.json" />
     <add key="YammerMessageURL" value="https://www.yammer.com/api/v1/messages.json" />
     <add key="YammerGetUserURL" value="https://www.yammer.com/api/v1/users/by_email.json?email={0}" />

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/Magenic.BadgeApplication.Yammer.Tests.csproj
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/Magenic.BadgeApplication.Yammer.Tests.csproj
@@ -1,0 +1,96 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Magenic.BadgeApplication.Yammer.Tests</RootNamespace>
+    <AssemblyName>Magenic.BadgeApplication.Yammer.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="YammerPublisherTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Magenic.BadgeApplication.Common\Magenic.BadgeApplication.Common.csproj">
+      <Project>{D7B48F98-7BD5-4E80-8740-6C348A7F9A1E}</Project>
+      <Name>Magenic.BadgeApplication.Common</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\Magenic.BadgeApplication.Yammer\Magenic.BadgeApplication.Yammer.csproj">
+      <Project>{7A376D75-249B-4A1D-BD7F-B80F720036C1}</Project>
+      <Name>Magenic.BadgeApplication.Yammer</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/Properties/AssemblyInfo.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Magenic.BadgeApplication.Yammer.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Magenic.BadgeApplication.Yammer.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("65add3a8-4cc8-4a40-8923-1df50150dc04")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/YammerPublisherTests.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/YammerPublisherTests.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Magenic.BadgeApplication.Yammer;
+using Magenic.BadgeApplication.Common.DTO;
+
+namespace Magenic.BadgeApplication.Yammer.Tests
+{
+	[TestClass]
+	public class YammerPublisherTests
+	{
+		[TestMethod]
+		public void PublishHarness()
+		{
+			var dto = new EarnedBadgeItemDTO
+			{
+				EmployeeADName = "billzi",
+				Name = "testBadgeName2",
+				ImagePath = "testImagePath2",
+				Tagline = "testTagLine2"
+			};
+
+			YammerPublisher yp = new YammerPublisher();
+
+			yp.Publish(dto);
+			
+
+		}
+	}
+}

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/YammerPublisherTests.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/YammerPublisherTests.cs
@@ -14,9 +14,9 @@ namespace Magenic.BadgeApplication.Yammer.Tests
 			var dto = new EarnedBadgeItemDTO
 			{
 				EmployeeADName = "billzi",
-				Name = "testBadgeName2",
-				ImagePath = "testImagePath2",
-				Tagline = "testTagLine2"
+				Name = "testBadgeName3",
+				ImagePath = "testImagePath3",
+				Tagline = "testTagLine3"
 			};
 
 			YammerPublisher yp = new YammerPublisher();

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
@@ -7,7 +7,8 @@
     <add key="NotificationDay" value="Monday"/>
     <add key="NotificationHourOfDay" value="12"/>
     <add key="YammerMessage" value="body=Attention Magenicons [[user:{0}]] has earned the {1} badge!&amp;broadcast={2}&amp;og_url={3}&amp;og_image={4}&amp;og_title={5}&amp;og_description={6}" />
-    
+    <add key="YammerToken" value="" />
+
     <!--<add key="YammerToken" value="Y3SGAUBvgDRVQWeTNfBA" />-->
     
     <add key="YammerCurrentUserURL" value="https://www.yammer.com/api/v1/users/current.json" />

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
@@ -7,8 +7,7 @@
     <add key="NotificationDay" value="Monday"/>
     <add key="NotificationHourOfDay" value="12"/>
     <add key="YammerMessage" value="body=Attention Magenicons [[user:{0}]] has earned the {1} badge!&amp;broadcast={2}&amp;og_url={3}&amp;og_image={4}&amp;og_title={5}&amp;og_description={6}" />
-    <add key="YammerToken" value="OQFYAGMMRuA55qu7dJLO2A" />
-
+    
     <!--<add key="YammerToken" value="Y3SGAUBvgDRVQWeTNfBA" />-->
     
     <add key="YammerCurrentUserURL" value="https://www.yammer.com/api/v1/users/current.json" />

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer.Tests/app.config
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <appSettings>
+    <add key="SleepIntervalInMilliseconds" value="60000" />
+    <add key="ErrorSleepIntervalInMilliseconds" value="3600000"/>
+    <add key="NotificationDay" value="Monday"/>
+    <add key="NotificationHourOfDay" value="12"/>
+    <add key="YammerMessage" value="body=Attention Magenicons [[user:{0}]] has earned the {1} badge!&amp;broadcast={2}&amp;og_url={3}&amp;og_image={4}&amp;og_title={5}&amp;og_description={6}" />
+    <add key="YammerToken" value="OQFYAGMMRuA55qu7dJLO2A" />
+
+    <!--<add key="YammerToken" value="Y3SGAUBvgDRVQWeTNfBA" />-->
+    
+    <add key="YammerCurrentUserURL" value="https://www.yammer.com/api/v1/users/current.json" />
+    <add key="YammerMessageURL" value="https://www.yammer.com/api/v1/messages.json" />
+    <add key="YammerGetUserURL" value="https://www.yammer.com/api/v1/users/by_email.json?email={0}" />
+    <add key="ClientSettingsProvider.ServiceUri" value="" />
+  </appSettings>
+
+</configuration>

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer/YammerPublisher.cs
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Yammer/YammerPublisher.cs
@@ -60,7 +60,7 @@ namespace Magenic.BadgeApplication.Yammer
                     yammerUser.UserID,
                     earnedBadge.Name,
                     broadcastToAll.ToString(),
-                    "https://badgeapplication.magenic.com/",
+					"https://badgeapplication.magenic.com/Leaderboard/show/" + earnedBadge.EmployeeADName,
                     earnedBadge.ImagePath,
                     earnedBadge.Name,
                     earnedBadge.Tagline);

--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.sln
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30501.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Magenic.BadgeApplication.Mvc", "Magenic.BadgeApplication.Mvc\Magenic.BadgeApplication.Mvc.csproj", "{5C2D04F9-153E-43BE-990B-6D6FCF5831FE}"
 EndProject
@@ -59,6 +59,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Libraries", "Libraries", "{
 	ProjectSection(SolutionItems) = preProject
 		Libraries\DocumentFormat.OpenXml.dll = Libraries\DocumentFormat.OpenXml.dll
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Magenic.BadgeApplication.Yammer.Tests", "Magenic.BadgeApplication.Yammer.Tests\Magenic.BadgeApplication.Yammer.Tests.csproj", "{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -181,6 +183,12 @@ Global
 		{54C1E80C-96C4-4071-BA53-555AF5E77995}.QA|Any CPU.Build.0 = Release|Any CPU
 		{54C1E80C-96C4-4071-BA53-555AF5E77995}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54C1E80C-96C4-4071-BA53-555AF5E77995}.Release|Any CPU.Build.0 = Release|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.QA|Any CPU.ActiveCfg = Release|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.QA|Any CPU.Build.0 = Release|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -190,5 +198,6 @@ Global
 		{15F6B4C8-7712-4E81-85EA-B4293E4C7C1E} = {D8B418F6-48F8-4B1B-9819-C0C68D1F6A49}
 		{03EBFAD6-39AE-4264-8B2B-A101402366A7} = {D8B418F6-48F8-4B1B-9819-C0C68D1F6A49}
 		{43B31581-1A4B-4876-96CC-70699E15F3FA} = {A6B06300-2261-4136-A86F-2BE3DD434CD0}
+		{65ADD3A8-4CC8-4A40-8923-1DF50150DC04} = {D8B418F6-48F8-4B1B-9819-C0C68D1F6A49}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This fix addresses the Yammer URL bug that had pointed to a non-existent location.   The corrected URL now points to the badge earner's location in the Badge Application.