### PR TITLE
Making the Error message more inclusive

### DIFF
--- a/Magenic.BadgeApplication/Magenic.BadgeApplication.Mvc/Views/Shared/_Layout.cshtml
+++ b/Magenic.BadgeApplication/Magenic.BadgeApplication.Mvc/Views/Shared/_Layout.cshtml
@@ -23,7 +23,7 @@
             {
                 <div class="alert alert-warning fade in">
                     <button class="close" aria-hidden="true" type="button" data-dismiss="alert">×</button>
-                    <h4>There were validation issues!</h4>
+                    <h4>Error(s) encoutered</h4>
                     <p>
                         @Html.ValidationSummary(false)
                     </p>


### PR DESCRIPTION
For this system EVERYTHING was a validation error versus log in error or other error.  Changing the heading to reflect the correct behavior.